### PR TITLE
Add missing markup formater for CredentialParameterDefinition

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsParameterDefinition/config.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsParameterDefinition/config.jelly
@@ -39,7 +39,7 @@
   <f:entry field="defaultValue" title="${%Default Value}">
     <c:select/>
   </f:entry>
-  <f:entry field="description" title="${%Description}" help="/help/parameter/description.html">
-    <f:textarea/>
+  <f:entry title="${%Description}" help="/help/parameter/description.html">
+    <f:textarea name="parameter.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
   </f:entry>
 </j:jelly>


### PR DESCRIPTION
This PR is intended to fix missing markup formatter for credentials parameter definition.